### PR TITLE
Bump gradle from 3.6.1 to 3.6.2 in /project

### DIFF
--- a/project/build.gradle
+++ b/project/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         classpath "org.jacoco:org.jacoco.core:${jacocoVersion}"
         classpath "io.objectbox:objectbox-gradle-plugin:2.5.1"
     }


### PR DESCRIPTION
Bumps gradle from 3.6.1 to 3.6.2.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>